### PR TITLE
Improve parsing safety in bridge utilities

### DIFF
--- a/layerk-bridge/contracts/rpc-utils/MulticallV2.sol
+++ b/layerk-bridge/contracts/rpc-utils/MulticallV2.sol
@@ -78,7 +78,7 @@ contract Multicall2 {
         blockHash = blockhash(block.number - 1);
     }
 
-    function tryAggregateGasRation(bool requireSuccess, Call[] memory calls)
+    function tryAggregateGasRatio(bool requireSuccess, Call[] memory calls)
         public
         returns (Result[] memory returnData)
     {
@@ -198,7 +198,7 @@ contract ArbMulticall2 {
         blockHash = blockhash(block.number - 1);
     }
 
-    function tryAggregateGasRation(bool requireSuccess, Call[] memory calls)
+    function tryAggregateGasRatio(bool requireSuccess, Call[] memory calls)
         public
         returns (Result[] memory returnData)
     {

--- a/layerk-bridge/contracts/tokenbridge/libraries/BytesParser.sol
+++ b/layerk-bridge/contracts/tokenbridge/libraries/BytesParser.sol
@@ -27,13 +27,15 @@ library BytesParser {
         if (input.length != 32) {
             return (false, 0);
         }
-        // TODO: try catch to handle error
-        uint256 inputNum = abi.decode(input, (uint256));
-        if (inputNum > type(uint8).max) {
+        try abi.decode(input, (uint256)) returns (uint256 inputNum) {
+            if (inputNum > type(uint8).max) {
+                return (false, 0);
+            }
+            res = uint8(inputNum);
+            success = true;
+        } catch {
             return (false, 0);
         }
-        res = uint8(inputNum);
-        success = true;
     }
 
     function toString(bytes memory input) internal pure returns (bool success, string memory res) {
@@ -63,9 +65,12 @@ library BytesParser {
                 res := inputTruncated
             }
         } else {
-            // TODO: try catch to handle error
-            success = true;
-            res = abi.decode(input, (string));
+            try abi.decode(input, (string)) returns (string memory decoded) {
+                success = true;
+                res = decoded;
+            } catch {
+                success = false;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- handle errors when decoding bytes in `BytesParser`
- rename misspelled `tryAggregateGasRation` to `tryAggregateGasRatio`

## Testing
- `yarn test` *(fails: package not present in lockfile)*